### PR TITLE
[result] 716s (11m 56s) - Hetzner vServer - AMD EPYC-Genoa Processor

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 | CPU | [GHC 9.12.4 build](src/Benchmark/BuildGhc.hs) | [hedgehog-1.7-dependencies](src/Benchmark/BuildCabalPackage.hs) | [hedgehog-1.7-build](src/Benchmark/BuildCabalPackage.hs) | [containers-0.8-ghci](src/Benchmark/Ghci.hs) |
 | --- | --- | --- | --- | --- |
 | [Intel Core i9-10900K](results/intel/10th/i9-10900K) | 526s (8m 46s) | 28s | 13s | 5s |
+| [AMD EPYC-Genoa Processor](results/amd/unknown/AMD_EPYC-Genoa_Processor) | 661s (11m 1s) | 27s | 21s | 7s |
 | [Intel Core i7-1165G7](results/intel/11th/i7-1165G7) | 715s (11m 55s) | - | - | - |
 | [Intel Core 2 Duo P8700](results/intel/core_2/P8700) | 3013s (50m 13s) | - | - | - |
 

--- a/raw/2026-04-22T10:14:42Z
+++ b/raw/2026-04-22T10:14:42Z
@@ -1,0 +1,67 @@
+### Add a description (optional)
+
+Ive benchmarked the cpx52 hetzner instance Ive been using for somethings.
+
+### Build times (seconds)
+
+ghc-9.12.4-build:661 hedgehog-1.7-dependencies:27 hedgehog-1.7-build:21 containers-0.8-ghci:7
+
+### Used number of threads
+
+12
+
+### CPU Name
+
+AMD EPYC-Genoa Processor
+
+### CPUID (vendor / family / model / stepping)
+
+AuthenticAMD / 25 / 17 / 0
+
+### Cores
+
+12
+
+### Threads
+
+12
+
+### Operating System
+
+Debian GNU/Linux
+
+### Architecture
+
+x86_64
+
+### Motherboard
+
+KVM Standard PC (Q35 + ICH9, 2009)
+
+### RAM Size (GB)
+
+23
+
+### System Vendor
+
+Hetzner
+
+### Product Category
+
+unknown
+
+### Chassis Type
+
+1
+
+### Product Family
+
+Hetzner_vServer
+
+### Product Name
+
+vServer
+
+### Product Version
+
+20171111

--- a/results/amd/unknown/AMD_EPYC-Genoa_Processor/vServer_2026-04-22T10:14:42Z.yaml
+++ b/results/amd/unknown/AMD_EPYC-Genoa_Processor/vServer_2026-04-22T10:14:42Z.yaml
@@ -1,0 +1,28 @@
+times:
+  containers-0.8-ghci: 7
+  ghc-9.12.4-build: 661
+  hedgehog-1.7-build: 21
+  hedgehog-1.7-dependencies: 27
+concurrency: 12
+system:
+  os: Debian GNU/Linux
+  arch: x86_64
+  vendor: Hetzner
+  product:
+    category: unknown
+    chassis_type: '1'
+    name: vServer
+    family: Hetzner_vServer
+    version: '20171111'
+  board:
+    name: 2009)
+    vendor: KVM Standard PC (Q35 + ICH9,
+  cpu:
+    name: AMD EPYC-Genoa Processor
+    cores: 12
+    threads: 12
+    vendor: AuthenticAMD
+    family: '25'
+    model: '17'
+    stepping: '0'
+  ram: 23


### PR DESCRIPTION
Close #50.