### PR TITLE
Revert "Use MD5 instead of SHA256 to protect against (accidental!) co…

### DIFF
--- a/src/Benchmark/Type.hs
+++ b/src/Benchmark/Type.hs
@@ -134,7 +134,7 @@ dryRunForest = fmap unlines . runWriter . \ commands -> do
         writeLine ""
         writeLine $ "# Ensure that " <> pack blob.path <> " exists; download if necessary."
         writeLine $ "# url: " <> pack blob.url
-        writeLine $ "# hash: " <> blob.hash
+        writeLine $ "# sha256: " <> blob.hash
         writeLine ""
         return []
 

--- a/src/Blob.hs
+++ b/src/Blob.hs
@@ -6,7 +6,7 @@ module Blob (
 
 import Imports
 
-import GHC.Fingerprint (getFileHash)
+import Data.Text qualified as T
 import System.Directory (doesFileExist, renameFile)
 
 import Command qualified
@@ -30,9 +30,9 @@ ensure url path = unless -< doesFileExist path $ do
 
 verify :: Blob -> IO ()
 verify Blob {..} = do
-  actual <- show <$> getFileHash path
+  actual <- sha256sum path
   when (actual /= hash) . error $ unlines [
-      "hash mismatch!"
+      "sha256sum mismatch!"
     , ""
     , "  url:      " <> pack url
     , "  file:     " <> pack path
@@ -43,6 +43,10 @@ verify Blob {..} = do
 requireAll :: IO ()
 requireAll = do
   Command.require "curl"
+  Command.require "sha256sum"
 
 curl :: [String] -> IO ()
 curl = Command.call "curl"
+
+sha256sum :: String -> IO Text
+sha256sum file = T.take 64 <$> Command.run "sha256sum" [file]

--- a/src/Run.hs
+++ b/src/Run.hs
@@ -42,7 +42,7 @@ sourceTarball dir = Tarball {
     blob = Blob {
       url = "https://downloads.haskell.org/~ghc/" <> version <> "/ghc-" <> version <> "-src.tar.gz"
     , path = dir </> "ghc-" <> version <> "-src.tar.gz"
-    , hash = "078e0272f52407601e24f054a1efc2c5"
+    , hash = "df71d96169056d3a6d7ec17498864cbdd5511bda196440dc38a692133833dfa4"
     }
   , root = "ghc-" <> version
   }

--- a/test/dry-run
+++ b/test/dry-run
@@ -8,7 +8,7 @@ export GHC=/path/to/ghc-9.12.4
 
 # Ensure that ~/.cache/ghc-bench/ghc-9.12.4-src.tar.gz exists; download if necessary.
 # url: https://downloads.haskell.org/~ghc/9.12.4/ghc-9.12.4-src.tar.gz
-# hash: 078e0272f52407601e24f054a1efc2c5
+# sha256: df71d96169056d3a6d7ec17498864cbdd5511bda196440dc38a692133833dfa4
 
 tar -xf ~/.cache/ghc-bench/ghc-9.12.4-src.tar.gz
 cd ghc-9.12.4


### PR DESCRIPTION
…rruption"

This reverts commit 11c7bab74d42f28a690662d0df8a3164b07132c4.